### PR TITLE
Update reference implementation links for token standards

### DIFF
--- a/IIPS/iip-2.md
+++ b/IIPS/iip-2.md
@@ -84,7 +84,8 @@ def tokenFallback(self, _from: Address, _value: int, _data: bytes):
 ```
 
 ## Implementation
-* https://github.com/icon-project/samples/tree/master/irc2_token
+* ~~https://github.com/icon-project/samples/tree/master/irc2_token~~
+* [A Java SCORE Library for ICON Standard Tokens](https://github.com/sink772/javaee-tokens)
 
 ## References
 * [https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md)

--- a/IIPS/iip-3.md
+++ b/IIPS/iip-3.md
@@ -100,7 +100,8 @@ def Approval(self, _owner: Address, _approved: Address, _tokenId: int):
 ```
 
 ## Implementation
-* [ICON IRC3 NFT Token Standard RI](https://github.com/icon2infiniti/Samples/tree/master/IRC3)
+* ~~[ICON IRC3 NFT Token Standard RI](https://github.com/icon2infiniti/Samples/tree/master/IRC3)~~
+* [A Java SCORE Library for ICON Standard Tokens](https://github.com/sink772/javaee-tokens)
 
 ## References
 * [https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md)

--- a/IIPS/iip-31.md
+++ b/IIPS/iip-31.md
@@ -259,7 +259,8 @@ def tokenURI(self, _id: int) -> str:
 ```
 
 ## Implementation
-* [ICON Multi-Token Standard Implementation](https://github.com/sink772/multi-token-standard)
+* ~~[ICON Multi-Token Standard Implementation](https://github.com/sink772/multi-token-standard)~~
+* [A Java SCORE Library for ICON Standard Tokens](https://github.com/sink772/javaee-tokens)
 
 ## References
 * [IRC-2 Token Standard](https://github.com/icon-project/IIPs/blob/master/IIPS/iip-2.md)


### PR DESCRIPTION
Deprecate Python RI links and update to Java RI links.