### PR TITLE
Fix indexed flags of BMC.Message() event

### DIFF
--- a/IIPS/iip-25.md
+++ b/IIPS/iip-25.md
@@ -552,10 +552,10 @@ def getStatus(self, _link: str) -> dict:
 
 ###### Message
 ```python
-@eventlog(indexed=1)
+@eventlog(indexed=2)
 def Message(self, _next: str, _seq: int, _msg: bytes):
 ```
-* Indexed: 1
+* Indexed: 2
 * Params
   - _next: String ( BTP Address of the BMC to handle the message )
   - _seq: Integer ( sequence number of the message from current BMC to the next )


### PR DESCRIPTION
Indexed flags of the events depend on the platform.
ICON uses 2 for it. So, it needs to be updated.
